### PR TITLE
Removed compilation optimizations and added line numbers for Valgrind

### DIFF
--- a/cs247_test.sh
+++ b/cs247_test.sh
@@ -34,7 +34,7 @@ do
 	if test -n "$(find $q_dir -regex '.*.cc')"
 	then
 		cc_files=$(ls -A $q_dir/*.cc)
-		g++ -o $q_dir/prog -w $cc_files # note: warnings omitted
+		g++ -o $q_dir/prog -w $cc_files -O0 -g # note: warnings omitted
 	fi
 
 


### PR DESCRIPTION
-O0 removes compilation optimizations
We should remove optimizations so it's easier to follow what went wrong in our code.
-g adds the Valgrind line numbers